### PR TITLE
Fix pathway ID sync

### DIFF
--- a/components/flowchart-builder/flowchart-builder.tsx
+++ b/components/flowchart-builder/flowchart-builder.tsx
@@ -542,6 +542,11 @@ export function FlowchartBuilder({
     )
   }
 
+  // Sync existingPathwayId with prop changes
+  useEffect(() => {
+    setExistingPathwayId(initialPathwayId || null)
+  }, [initialPathwayId])
+
   // Load saved flowchart on component mount
   useEffect(() => {
     try {


### PR DESCRIPTION
## Summary
- update FlowchartBuilder to sync `existingPathwayId` when `initialPathwayId` changes

## Testing
- `npx next lint` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_b_6847cf09d0a48325b6197c518f08f9a3